### PR TITLE
Limit the number of samples to 5000 per scrape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM prom/prometheus:v2.0.0
+FROM prom/prometheus:v2.2.1
 ADD prometheus.yml /etc/prometheus/

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -33,6 +33,7 @@ scrape_configs:
     ec2_sd_configs:
      - region: eu-west-1
        port: 9095
+    sample_limit: 5000
     relabel_configs:
      - source_labels: [__meta_ec2_tag_Environment]
        target_label: environment


### PR DESCRIPTION
In order to handle cardinality explosion a bit more gracefully, we should
limit the number of samples (time series) that Prometheus processes after
querying a target. For the time being, we set this to 5000.

This can be monitored via
`prometheus_target_scrapes_exceeded_sample_limit_total`.

In addition, this PR updates to the latest Prometheus version.